### PR TITLE
Improvements on two checkers

### DIFF
--- a/DuplicatePathChecker.cs
+++ b/DuplicatePathChecker.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 
 namespace PathCleaner
 {
@@ -8,8 +9,18 @@ namespace PathCleaner
 
         public bool Identify(string folder, string previousFolder)
         {
-            return previousFolder != null 
-                && String.Compare(folder, previousFolder, StringComparison.OrdinalIgnoreCase) == 0;
+            if (previousFolder == null)
+            {
+                return false;
+            }
+
+            return string.Compare(trimTrailingPathSeparators(folder), 
+                       trimTrailingPathSeparators(previousFolder), StringComparison.OrdinalIgnoreCase) == 0;
+        }
+
+        private static string trimTrailingPathSeparators(string path)
+        {
+            return path.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
         }
     }
 }

--- a/NoExecutablesPathChecker.cs
+++ b/NoExecutablesPathChecker.cs
@@ -12,6 +12,20 @@ namespace PathCleaner
             ".exe", ".com", ".bat", ".cmd", ".ps1", ".dll"
         };
 
+        static NoExecutablesPathChecker()
+        {
+            string rawText = Environment.GetEnvironmentVariable("PATHEXT", EnvironmentVariableTarget.Machine);
+            if (rawText == null)
+            {
+                return;
+            }
+
+            foreach (string ext in rawText.Split(';').Where(ext => !string.IsNullOrWhiteSpace(ext)))
+            {
+                executableExtensions.Add(ext);
+            }
+        }
+
         public string Reason => "No executables";
 
         public bool Identify(string folder, string previousFolder)


### PR DESCRIPTION
- Trailing directory separators will be ignored. A path pair such as `C:\path` and `C:\path\` will now be treated as equal.
- `NoExecutablesPathChecker` is now PATHEXT-aware. User-defined extensions will also be used when searching for executable file entries as `cmd` and other compatible terminals do.